### PR TITLE
Allow the periodic re-generation of configuration files to be disabled

### DIFF
--- a/base/rootfs/etc/services.d/confd/run
+++ b/base/rootfs/etc/services.d/confd/run
@@ -5,6 +5,7 @@ readonly ETCD_HOST=${ETCD_HOST:-etcd}
 readonly ETCD_HOST_PORT=${ETCD_HOST_PORT:-2379}
 readonly ETCD_CONNECTION_TIMEOUT=${ETCD_CONNECTION_TIMEOUT:-0}
 readonly CONFD_LOG_LEVEL=${CONFD_LOG_LEVEL:-error}
+readonly CONFD_NOOP=${CONFD_NOOP:-false}
 readonly CONFD_POLLING_INTERVAL=${CONFD_POLLING_INTERVAL:-5}
 
 echo "Looking for etcd server... http://${ETCD_HOST}:${ETCD_HOST_PORT}"
@@ -13,5 +14,11 @@ if timeout ${ETCD_CONNECTION_TIMEOUT} wait-for-open-port.sh ${ETCD_HOST} ${ETCD_
   confd -log-level ${CONFD_LOG_LEVEL} -interval ${CONFD_POLLING_INTERVAL} -backend etcdv3 -node ${ETCD_HOST}:${ETCD_HOST_PORT}
 else 
   echo "Timeout exceeded using env backend..."
-  confd -log-level ${CONFD_LOG_LEVEL} -interval ${CONFD_POLLING_INTERVAL} -backend env 
+  if [ ${CONFD_NOOP} == true ] ;
+  then
+    echo "WARNING confd: noop execution! (CONFD_NOOP == true)"
+    confd -noop -log-level ${CONFD_LOG_LEVEL} -interval ${CONFD_POLLING_INTERVAL} -backend env
+  else
+    confd -log-level ${CONFD_LOG_LEVEL} -interval ${CONFD_POLLING_INTERVAL} -backend env
+  fi
 fi


### PR DESCRIPTION
Support disabling regeneration of configuration files by setting environment variable CONFD_NOOP == true